### PR TITLE
Ensure proper coeffs reference in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
     install_requires=[
         "NumPy"
     ],
-    package_data={'': ['src/igrf12coeffs.txt']}
+    package_data={'': ['src/igrf13coeffs.txt']}
 )


### PR DESCRIPTION
In the latest release, 0.3.0, importing the package fails due to missing coefficients file. This small fix corrects it. Found while creating conda package: https://github.com/conda-forge/pyigrf-feedstock/pull/1